### PR TITLE
Atomic section management and correct trace generation on partial order

### DIFF
--- a/src/cbmc/bmc.cpp
+++ b/src/cbmc/bmc.cpp
@@ -343,7 +343,10 @@ safety_checkert::resultt bmct::run(
     setup_unwind();
 
     // perform symbolic execution
-    symex(goto_functions);
+    // FIXME: we recommend to pass the option on the constructor
+    // currently done here since we want to have a minimal code change
+    // until this functionality is decided
+    symex(goto_functions, options.get_bool_option("atomic-nesting"));
 
     // add a partial ordering, if required
     if(equation.has_threads())

--- a/src/goto-symex/build_goto_trace.cpp
+++ b/src/goto-symex/build_goto_trace.cpp
@@ -188,6 +188,7 @@ void build_goto_trace(
 
   const goto_trace_stept *end_ptr=nullptr;
   bool end_step_seen=false;
+  bool start_step_seen=false;
 
   for(symex_target_equationt::SSA_stepst::const_iterator
       it=target.SSA_steps.begin();
@@ -217,6 +218,11 @@ void build_goto_trace(
     else if(it->is_shared_read() || it->is_shared_write() ||
             it->is_atomic_end())
     {
+      // Shared r/w before the first step correspond to unused traces
+      // In general the first step in the trace is necessarily in time 0
+      if (!start_step_seen)
+        continue;
+      
       mp_integer time_before=current_time;
 
       if(it->is_shared_read() || it->is_shared_write())
@@ -255,6 +261,9 @@ void build_goto_trace(
     {
       continue;
     }
+
+    // Set start step to true if not previously seen
+    start_step_seen=true;
 
     goto_tracet::stepst &steps=time_map[current_time];
     steps.push_back(goto_trace_stept());

--- a/src/goto-symex/goto_symex.h
+++ b/src/goto-symex/goto_symex.h
@@ -12,6 +12,8 @@ Author: Daniel Kroening, kroening@kroening.com
 #ifndef CPROVER_GOTO_SYMEX_GOTO_SYMEX_H
 #define CPROVER_GOTO_SYMEX_GOTO_SYMEX_H
 
+#include <stack>
+
 #include <util/options.h>
 #include <util/byte_operators.h>
 
@@ -53,6 +55,7 @@ public:
     ns(_ns),
     target(_target),
     atomic_section_counter(0),
+    allow_atomic_nesting(false),
     guard_identifier("goto_symex::\\guard")
   {
     options.set_option("simplify", true);
@@ -67,7 +70,8 @@ public:
 
   /** symex all at once, starting from entry point */
   virtual void operator()(
-    const goto_functionst &goto_functions);
+    const goto_functionst &goto_functions,
+    bool atomic_nesting=false);
 
   /** symex starting from given goto program */
   virtual void operator()(
@@ -104,6 +108,8 @@ protected:
   const namespacet &ns;
   symex_targett &target;
   unsigned atomic_section_counter;
+  bool allow_atomic_nesting;
+  std::stack<unsigned> atomic_sections;
 
   friend class symex_dereference_statet;
 

--- a/src/goto-symex/symex_goto.cpp
+++ b/src/goto-symex/symex_goto.cpp
@@ -237,7 +237,9 @@ void goto_symext::merge_goto(
 {
   // check atomic section
   if(state.atomic_section_id!=goto_state.atomic_section_id)
-    throw "atomic sections differ across branches";
+    throw "atomic sections differ across branches at "+
+      goto_state.source.pc->source_location.as_string() +
+        " and " + state.source.pc->source_location.as_string();
 
   // do SSA phi functions
   phi_function(goto_state, state);

--- a/src/goto-symex/symex_main.cpp
+++ b/src/goto-symex/symex_main.cpp
@@ -172,8 +172,10 @@ void goto_symext::operator()(
 }
 
 /// symex from entry point
-void goto_symext::operator()(const goto_functionst &goto_functions)
+void goto_symext::operator()(const goto_functionst &goto_functions,
+                             bool atomic_nesting)
 {
+  allow_atomic_nesting=atomic_nesting;
   goto_functionst::function_mapt::const_iterator it=
     goto_functions.function_map.find(goto_functionst::entry_point());
 

--- a/src/java_bytecode/library/src/java/lang/Object.java
+++ b/src/java_bytecode/library/src/java/lang/Object.java
@@ -149,8 +149,8 @@ public class Object {
     
     public static void monitorenter(Object object)
     {
-      if (object == null) //FIXME : remove last entry of the stack trace
-        throw new NullPointerException();
+      // if (object == null) //FIXME : remove last entry of the stack trace
+      //   throw new NullPointerException();
       int id=CProver.getCurrentThreadID();
       CProver.atomicBegin();
       CProver.assume((object.monitorCount == 0)


### PR DESCRIPTION
test-gen will require enabling an option for atomic-nesting
The nesting is done by keeping track of the atomic section stack and using only the most outward at each step.  This is done at the ssa level where all functions are inlined. 